### PR TITLE
Transition to `LinearAlgebra.BLAS.libblastrampoline` instead of `Base.liblapack_name`

### DIFF
--- a/src/KalmanFilters.jl
+++ b/src/KalmanFilters.jl
@@ -8,7 +8,11 @@ module KalmanFilters
         Statistics,
         FFTW
 
-    const liblapack = Base.liblapack_name
+    if isdefined(LinearAlgebra.BLAS, :libblastrampoline)
+        const liblapack = LinearAlgebra.BLAS.libblastrampoline
+    else
+        const liblapack = Base.liblapack_name
+    end
     
     import Statistics: mean, cov
 


### PR DESCRIPTION
This change is in support of https://github.com/JuliaLang/julia/pull/50699