### PR TITLE
Significant speed-up to SRKF for low dimensions using StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/benchmark/static_arrays_benchmark.jl
+++ b/benchmark/static_arrays_benchmark.jl
@@ -1,0 +1,69 @@
+using KalmanFilters
+using LinearAlgebra
+using StaticArrays
+
+Dx = 2
+Dy = 2
+
+F = @SMatrix rand(Dx, Dx)
+Q = @SMatrix rand(Dx, Dx)
+Q = Q * Q'
+H = @SMatrix rand(Dy, Dx)
+R = @SMatrix rand(Dy, Dy)
+R = R * R'
+x_init = @SVector rand(Dx)
+P_init = @SMatrix rand(Dx, Dx)
+P_init = P_init * P_init'
+measurement = @SVector rand(Dy)
+
+P_init_chol = cholesky(P_init)
+Q_chol = cholesky(Q)
+R_chol = cholesky(R)
+tu = time_update(x_init, P_init_chol, F, Q_chol)
+mu = measurement_update(get_state(tu), get_sqrt_covariance(tu), measurement, H, R_chol)
+
+# Confirm output type is correct
+println("Output Type: ", typeof(mu.covariance))
+
+# Benchmark against regular array version
+using BenchmarkTools
+
+println("StaticArrays:")
+res_static = @benchmark begin
+    tu = time_update($x_init, $P_init_chol, $F, $Q_chol)
+    mu = measurement_update(get_state(tu), get_sqrt_covariance(tu), $measurement, $H, $R_chol)
+    for i in 1:100
+        tu = time_update(get_state(tu), get_sqrt_covariance(tu), $F, $Q_chol)
+        mu = measurement_update(get_state(tu), get_sqrt_covariance(tu), $measurement, $H, $R_chol)
+    end
+end
+display(res_static)
+
+println("Regular Arrays:")
+F_reg = rand(Dx, Dx)
+Q_reg = rand(Dx, Dx)
+Q_reg = Q_reg * Q_reg'
+H_reg = rand(Dy, Dx)
+R_reg = rand(Dy, Dy)
+R_reg = R_reg * R_reg'
+x_init_reg = rand(Dx)
+P_init_reg = rand(Dx, Dx)
+P_init_reg = P_init_reg * P_init_reg'
+measurement_reg = rand(Dy)
+
+P_init_chol_reg = cholesky(P_init_reg)
+Q_chol_reg = cholesky(Q_reg)
+R_chol_reg = cholesky(R_reg)
+
+res_regular = @benchmark begin
+    tu = time_update($x_init_reg, $P_init_chol_reg, $F_reg, $Q_chol_reg)
+    mu = measurement_update(get_state(tu), get_sqrt_covariance(tu), $measurement_reg, $H_reg, $R_chol_reg)
+    for i in 1:100
+        tu = time_update(get_state(tu), get_sqrt_covariance(tu), $F_reg, $Q_chol_reg)
+        mu = measurement_update(get_state(tu), get_sqrt_covariance(tu), $measurement_reg, $H_reg, $R_chol_reg)
+    end
+end
+display(res_regular)
+
+# Print speed-up
+println("Speed-up: ", mean(res_regular.times) / mean(res_static.times[1]))

--- a/src/KalmanFilters.jl
+++ b/src/KalmanFilters.jl
@@ -21,6 +21,8 @@ module KalmanFilters
     import ..LinearAlgebra: BlasFloat, BlasInt,
         DimensionMismatch, chkstride1, checksquare, cholesky
 
+    import StaticArrays: SVector, SMatrix, SOneTo
+
     export
         WanMerweWeightingParameters,
         MeanSetWeightingParameters,


### PR DESCRIPTION
I was doing some testing/benchmarking of the SRKF provided by this package and noticed that some of the operations used in the current implement cast SMatrices back to regular arrays, losing the speed benefits.

I've added a few method specialisations that avoid this, which leads to a 20x speed-up in the Dx = Dy = 2 case, shown in `benchmarks/static_arrays_benchmarks`. 

For my downstream use-case, which would involve running multiple SRKFs in parallel, the speed-up would be even greater since StaticArrays is not using any multithreading currently like LAPACK would.

I originally tried to modify the existing code so that it could work with both regular and static arrays. It's possible to do this (the output of measurement/time update is still a static array) by using `@views` in `extract_cross_covariance` etc. but this only leads to a 2–3x speed-up.

I appreciate that this change adds a bit of bloat to the code-base, so I'd be more than happy to just implement it in our downstream use-case. If this is something you would like in this package, let me know, and I can look at making these changes over all of the algorithms.