### PR TITLE
Adding state corrections.

### DIFF
--- a/src/KalmanFilters.jl
+++ b/src/KalmanFilters.jl
@@ -43,6 +43,7 @@ export WanMerweWeightingParameters,
     get_innovation,
     get_innovation_covariance,
     get_kalman_gain,
+    get_state_correction,
     get_sqrt_covariance,
     get_sqrt_innovation_covariance,
     time_update,
@@ -73,6 +74,7 @@ end
 get_innovation(kf::AbstractMeasurementUpdate) = kf.innovation
 get_innovation_covariance(kf::AbstractMeasurementUpdate) = kf.innovation_covariance
 get_kalman_gain(kf::AbstractMeasurementUpdate) = kf.kalman_gain
+get_state_correction(kf::AbstractMeasurementUpdate) = kf.state_correction
 
 function get_covariance(kf::AbstractUpdate{X,P}) where {X,P<:Cholesky}
     kf.covariance.L * kf.covariance.U

--- a/src/aukf.jl
+++ b/src/aukf.jl
@@ -42,6 +42,7 @@ function AUKFMUIntermediate(T::Type, num_x::Number, num_y::Number)
         Matrix{T}(undef, num_x, num_y),
         Vector{T}(undef, num_x),
         Matrix{T}(undef, num_x, num_x),
+        Vector{T}(undef, num_x),
     )
 end
 

--- a/src/consider.jl
+++ b/src/consider.jl
@@ -3,11 +3,15 @@
     PHᵀ[not_consider, :] / S
 end
 
-@inline function calc_posterior_state(x, K, ỹ, consider::AbstractVector)
+@inline function calc_posterior_state(x, x̃, consider::AbstractVector)
     not_consider = filter(i -> !(i in consider), 1:length(x))
     x_post = copy(x)
-    x_post[not_consider] = x[not_consider] + K * ỹ
+    x_post[not_consider] = x[not_consider] + x̃
     x_post
+end
+
+@inline function calc_posterior_state(x, K, ỹ, consider::AbstractVector)
+    calc_posterior_state(x, K * ỹ, consider::AbstractVector)
 end
 
 @inline function calc_posterior_covariance(P, PHᵀ, K, consider::AbstractVector)

--- a/src/ekf.jl
+++ b/src/ekf.jl
@@ -115,9 +115,10 @@ function measurement_update(
     PHᵀ = calc_P_xy(P, gradient_or_jacobian)
     S = calc_innovation_covariance(gradient_or_jacobian, P, R)
     K = calc_kalman_gain(PHᵀ, S, consider)
-    x_post = calc_posterior_state(x, K, ỹ, consider)
+    x̃ = calc_state_correction(K, ỹ)
+    x_post = calc_posterior_state(x, x̃, consider)
     P_post = calc_posterior_covariance(P, PHᵀ, K, consider)
-    KFMeasurementUpdate(x_post, P_post, ỹ, S, K)
+    KFMeasurementUpdate(x_post, P_post, ỹ, S, K, x̃)
 end
 
 calc_innovation(y_pre, y) = y - y_pre

--- a/src/sigmapoints.jl
+++ b/src/sigmapoints.jl
@@ -102,6 +102,7 @@ struct SPMeasurementUpdate{X,P,O,I,IC,K} <: AbstractMeasurementUpdate{X,P}
     innovation::I
     innovation_covariance::IC
     kalman_gain::K
+    state_correction::X
 end
 
 abstract type AbstractSigmaPoints{T} <: AbstractMatrix{T} end

--- a/src/sraukf.jl
+++ b/src/sraukf.jl
@@ -55,6 +55,7 @@ function SRAUKFMUIntermediate(T::Type, num_x::Number, num_y::Number)
         Matrix{T}(undef, num_x, num_y),
         Vector{T}(undef, num_x),
         Matrix{T}(undef, num_x, num_x),
+        Vector{T}(undef, num_x),
     )
 end
 

--- a/src/srukf.jl
+++ b/src/srukf.jl
@@ -56,6 +56,7 @@ struct SRUKFMUIntermediate{T,X,TS,AS<:Union{Matrix{T},Augmented{Matrix{T},Matrix
     kalman_gain::Matrix{T}
     x_posterior::Vector{T}
     p_posterior::Matrix{T}
+    x_correction::Vector{T}
 end
 
 function SRUKFMUIntermediate(T::Type, num_x::Number, num_y::Number)
@@ -86,6 +87,7 @@ function SRUKFMUIntermediate(T::Type, num_x::Number, num_y::Number)
         Matrix{T}(undef, num_x, num_y),
         Vector{T}(undef, num_x),
         Matrix{T}(undef, num_x, num_x),
+        Vector{T}(undef, num_x),
     )
 end
 
@@ -274,6 +276,7 @@ function measurement_update!(
         Pᵪᵧ,
         S,
     )
-    x_posterior = calc_posterior_state!(mu.x_posterior, x, K, mu.ỹ)
-    SPMeasurementUpdate(x_posterior, P_posterior, 𝓨, mu.ỹ, S, K)
+    x̃ = calc_state_correction!(mu.x_correction, K, mu.ỹ)
+    x_posterior = calc_posterior_state!(mu.x_posterior, x, x̃)
+    SPMeasurementUpdate(x_posterior, P_posterior, 𝓨, mu.ỹ, S, K, x̃)
 end

--- a/test/kf.jl
+++ b/test/kf.jl
@@ -33,6 +33,12 @@
         @test KalmanFilters.calc_kalman_gain!(S_lu, K, PHᵀ, S) ≈ PHᵀ / S
 
         x = randn(2)
+        x_correction = similar(x)
+        K = randn(2, 2)
+        ỹ = randn(2)
+        @test KalmanFilters.calc_state_correction!(x_correction, K, ỹ) ≈ K * ỹ
+
+        x = randn(2)
         x_posterior = similar(x)
         K = randn(2, 2)
         ỹ = randn(2)


### PR DESCRIPTION
This pull request proposes to also store the state correction of the measurement update step. The state correction can be a useful parameter in some applications.

In ukf.jl line 126 and srkf.jl line 58, a typecasting of the state correction is made to pass some of the tests. Maybe somebody finds a more elegant way to implement this.