### PR TITLE
ci(compat-helper): use ssh key in order to trigger ci tests

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -46,5 +46,5 @@ jobs:
           # Either way, we need an SSH key if we want the PRs that CompatHelper creates to be able to trigger CI workflows themselves.
           # That is because GITHUB_TOKEN's can't trigger other workflows (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
           # Check if you have a deploy key setup using these docs: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/reviewing-your-deploy-keys.
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+          # COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}


### PR DESCRIPTION
    If the compat helper uses GITHUB_TOKEN it won't trigger
    subsequent CI tests. Hence, let's use a SSH key instead.